### PR TITLE
[unauth-sign-up] Support no enrolment for sign-up journey

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -186,5 +186,5 @@ contact-preferences-frontend {
 }
 
 features {
-    bypassAuthEnabled = true
+    bypassAuthEnabled = false
 }

--- a/it/stubs/AuthStub.scala
+++ b/it/stubs/AuthStub.scala
@@ -16,9 +16,8 @@
 
 package stubs
 
-import assets.CommonITConstants._
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
-import play.api.http.Status.{OK, UNAUTHORIZED}
+import play.api.http.Status.OK
 import play.api.libs.json.{JsObject, Json}
 import utils.WireMockMethods
 
@@ -26,39 +25,9 @@ object AuthStub extends WireMockMethods {
 
   private val authoriseUri = "/auth/authorise"
 
-  private val mtdVatEnrolment = Json.obj(
-    "key" -> "HMRC-MTD-VAT",
-    "identifiers" -> Json.arr(
-      Json.obj(
-        "key" -> "VRN",
-        "value" -> vrn
-      )
-    )
-  )
-
-  private val otherEnrolment = Json.obj(
-    "key" -> "HMRC-XXX-XXX",
-    "identifiers" -> Json.arr(
-      Json.obj(
-        "key" -> "XXX",
-        "value" -> "XXX"
-      )
-    )
-  )
-
   def authorisedIndividual(): StubMapping = {
     when(method = POST, uri = authoriseUri)
-      .thenReturn(status = OK, body = successfulAuthResponse(mtdVatEnrolment))
-  }
-
-  def unauthorisedIndividualMissingEnrolment(): StubMapping = {
-    when(method = POST, uri = authoriseUri)
-      .thenReturn(status = UNAUTHORIZED, body = successfulAuthResponse(otherEnrolment))
-  }
-
-  def unauthenticated(): StubMapping = {
-    when(method = POST, uri = authoriseUri)
-      .thenReturn(status = UNAUTHORIZED, headers = Map("WWW-Authenticate" -> """MDTP detail="MissingBearerToken""""))
+      .thenReturn(status = OK, body = successfulAuthResponse())
   }
 
   private def successfulAuthResponse(enrolments: JsObject*): JsObject = Json.obj("allEnrolments" -> enrolments)

--- a/test/assets/BaseTestConstants.scala
+++ b/test/assets/BaseTestConstants.scala
@@ -26,7 +26,6 @@ object BaseTestConstants {
   val testVatNumber: String = "999999999"
   val testArn: String = "XARN1234567"
 
-  val testMtdVatEnrolment: Enrolment = Enrolment(MtdContactPreferencesEnrolmentKey).withIdentifier(MtdContactPreferencesReferenceKey, testVatNumber)
   val testAgentServicesEnrolment: Enrolment = Enrolment(AgentServicesEnrolment).withIdentifier(AgentServicesReference, testArn)
   val testCredentials: Credentials = Credentials("GG123456789", "GG")
 

--- a/test/connectors/mocks/MockAuthConnector.scala
+++ b/test/connectors/mocks/MockAuthConnector.scala
@@ -45,9 +45,9 @@ trait MockAuthConnector extends MockFactory {
       )
     )
 
-  def mockAuthRetrieveMtdVatEnrolled(predicate: Predicate = EmptyPredicate): Unit =
+  def mockAuthenticated(predicate: Predicate = EmptyPredicate): Unit =
     mockAuthorise(predicate = predicate, retrievals = retrievals)(
-      Future.successful(Enrolments(Set(testMtdVatEnrolment)))
+      Future.successful(Enrolments(Set()))
     )
 
 }

--- a/test/controllers/ContactPreferenceControllerSpec.scala
+++ b/test/controllers/ContactPreferenceControllerSpec.scala
@@ -27,6 +27,7 @@ import play.api.mvc.Result
 import play.api.test.FakeRequest
 import repositories.mocks.{MockContactPreferenceRepository, MockJourneyRepository}
 import services.mocks.{MockAuthService, MockContactPreferenceService, MockDateService, MockUUIDService}
+import uk.gov.hmrc.auth.core.authorise.EmptyPredicate
 
 import scala.concurrent.Future
 
@@ -54,7 +55,7 @@ class ContactPreferenceControllerSpec extends MockContactPreferenceRepository
       "successfully updated contactPreference repository" should {
 
         "return an Ok" in {
-          mockAuthRetrieveMtdVatEnrolled(vatAuthPredicate)
+          mockAuthenticated(EmptyPredicate)
           setupMockFindJourneyById(Some(journeyDocumentMax))
           setupMockUpdatePreference(digitalPreferenceDocumentModel, MockUUIDService.generateUUID)(true)
           status(result) shouldBe Status.NO_CONTENT
@@ -64,7 +65,7 @@ class ContactPreferenceControllerSpec extends MockContactPreferenceRepository
       "failed at updating contactPreference repository" should {
 
         "return an InternalServerError" in {
-          mockAuthRetrieveMtdVatEnrolled(vatAuthPredicate)
+          mockAuthenticated(EmptyPredicate)
           setupMockFindJourneyById(Some(journeyDocumentMax))
           setupMockUpdatePreference(digitalPreferenceDocumentModel, MockUUIDService.generateUUID)(false)
           status(result) shouldBe Status.INTERNAL_SERVER_ERROR
@@ -74,7 +75,7 @@ class ContactPreferenceControllerSpec extends MockContactPreferenceRepository
       "fails to update Contact preference repository" should {
 
         "return an InternalServerError" in {
-          mockAuthRetrieveMtdVatEnrolled(vatAuthPredicate)
+          mockAuthenticated(EmptyPredicate)
           setupMockFindJourneyById(Some(journeyDocumentMax))
           setupMockFailedUpdatePreference(digitalPreferenceDocumentModel, MockUUIDService.generateUUID)
           status(result) shouldBe Status.SERVICE_UNAVAILABLE
@@ -90,7 +91,7 @@ class ContactPreferenceControllerSpec extends MockContactPreferenceRepository
       lazy val result: Future[Result] = TestContactPreferenceController.findContactPreference(MockUUIDService.generateUUID)(fakeRequest)
 
       "return status Ok" in {
-        mockAuthRetrieveMtdVatEnrolled(vatAuthPredicate)
+        mockAuthenticated(EmptyPredicate)
         setupMockFindJourneyById(Some(journeyDocumentMax))
         setupMockFindPreferenceById(Some(digitalPreferenceDocumentModel))
         status(result) shouldBe Status.OK
@@ -104,7 +105,7 @@ class ContactPreferenceControllerSpec extends MockContactPreferenceRepository
     "fails to findById in the journey repository" should {
 
       "return NotFound" in {
-        mockAuthRetrieveMtdVatEnrolled(vatAuthPredicate)
+        mockAuthenticated(EmptyPredicate)
         setupMockFindJourneyById(Some(journeyDocumentMax))
         setupMockFailedFindPreferenceById(None)
         status(TestContactPreferenceController.findContactPreference(MockUUIDService.generateUUID)(fakeRequest)) shouldBe Status.SERVICE_UNAVAILABLE
@@ -114,7 +115,7 @@ class ContactPreferenceControllerSpec extends MockContactPreferenceRepository
     "given an id not contained in the contactPreference repository" should {
 
       "return NotFound" in {
-        mockAuthRetrieveMtdVatEnrolled(vatAuthPredicate)
+        mockAuthenticated(EmptyPredicate)
         setupMockFindJourneyById(Some(journeyDocumentMax))
         setupMockFindPreferenceById(None)
         status(TestContactPreferenceController.findContactPreference(MockUUIDService.generateUUID)(fakeRequest)) shouldBe Status.NOT_FOUND
@@ -129,7 +130,7 @@ class ContactPreferenceControllerSpec extends MockContactPreferenceRepository
       lazy val result: Future[Result] = TestContactPreferenceController.getDesContactPreference(MTDVAT, VRN, BaseTestConstants.testVatNumber)(fakeRequest)
 
       "return status Ok" in {
-        mockAuthRetrieveMtdVatEnrolled(vatAuthPredicate)
+        mockAuthenticated(EmptyPredicate)
         mockDesContactPreference(RegimeTestConstants.regimeModel)(Right(ContactPreferenceModel(Digital)))
         status(result) shouldBe Status.OK
       }
@@ -142,7 +143,7 @@ class ContactPreferenceControllerSpec extends MockContactPreferenceRepository
     "given an error response is returned from the service" should {
 
       "return NotFound" in {
-        mockAuthRetrieveMtdVatEnrolled(vatAuthPredicate)
+        mockAuthenticated(EmptyPredicate)
         mockDesContactPreference(RegimeTestConstants.regimeModel)(Left(InvalidJson))
         status(
           TestContactPreferenceController.getDesContactPreference(MTDVAT, VRN, BaseTestConstants.testVatNumber)(fakeRequest)

--- a/test/controllers/JourneyControllerSpec.scala
+++ b/test/controllers/JourneyControllerSpec.scala
@@ -23,6 +23,7 @@ import play.api.mvc.Result
 import play.api.test.FakeRequest
 import repositories.mocks.MockJourneyRepository
 import services.mocks.{MockAuthService, MockDateService, MockUUIDService}
+import uk.gov.hmrc.auth.core.authorise.EmptyPredicate
 
 import scala.concurrent.Future
 
@@ -49,13 +50,13 @@ class JourneyControllerSpec extends MockJourneyRepository with MockAuthService {
 
         "return an Ok" in {
           setupMockInsertJourney(journeyDocumentMax)(true)
-          mockAuthRetrieveMtdVatEnrolled(vatAuthPredicate)
+          mockAuthenticated(EmptyPredicate)
           status(result) shouldBe Status.CREATED
         }
 
         "have a location header with a redirect to the contact preferences FE" in {
           setupMockInsertJourney(journeyDocumentMax)(true)
-          mockAuthRetrieveMtdVatEnrolled(vatAuthPredicate)
+          mockAuthenticated(EmptyPredicate)
           redirectLocation(result) shouldBe Some(appConfig.contactPreferencesUrl + s"/${MockUUIDService.generateUUID}")
         }
       }
@@ -64,7 +65,7 @@ class JourneyControllerSpec extends MockJourneyRepository with MockAuthService {
 
         "return an InternalServerError" in {
           setupMockInsertJourney(journeyDocumentMax)(false)
-          mockAuthRetrieveMtdVatEnrolled(vatAuthPredicate)
+          mockAuthenticated(EmptyPredicate)
           status(result) shouldBe Status.INTERNAL_SERVER_ERROR
         }
       }
@@ -73,7 +74,7 @@ class JourneyControllerSpec extends MockJourneyRepository with MockAuthService {
 
         "return an InternalServerError" in {
           setupMockFailedInsertJourney(journeyDocumentMax)
-          mockAuthRetrieveMtdVatEnrolled(vatAuthPredicate)
+          mockAuthenticated(EmptyPredicate)
           status(result) shouldBe Status.SERVICE_UNAVAILABLE
         }
       }
@@ -107,7 +108,7 @@ class JourneyControllerSpec extends MockJourneyRepository with MockAuthService {
       lazy val result: Future[Result] = TestJourneyController.findJourney("id")(fakeRequest)
 
       "return status Ok" in {
-        mockAuthRetrieveMtdVatEnrolled(vatAuthPredicate)
+        mockAuthenticated(EmptyPredicate)
         setupMockFindJourneyById(Some(journeyDocumentMax))
         status(result) shouldBe Status.OK
       }

--- a/test/services/AuthServiceSpec.scala
+++ b/test/services/AuthServiceSpec.scala
@@ -23,7 +23,7 @@ import connectors.mocks.MockAuthConnector
 import play.api.http.Status._
 import play.api.mvc.Result
 import play.api.mvc.Results._
-import uk.gov.hmrc.auth.core.authorise.Predicate
+import uk.gov.hmrc.auth.core.authorise.{EmptyPredicate, Predicate}
 import uk.gov.hmrc.auth.core.{Enrolment, InsufficientEnrolments, MissingBearerToken}
 import utils.TestUtils
 
@@ -38,11 +38,6 @@ class AuthServiceSpec extends MockAuthConnector with TestUtils {
       Future.successful(Ok)
   }
 
-  val authPredicate: Predicate =
-    Enrolment(Constants.MtdContactPreferencesEnrolmentKey)
-      .withIdentifier(Constants.MtdContactPreferencesReferenceKey, testVatNumber)
-      .withDelegatedAuthRule(Constants.MtdContactPreferencesDelegatedAuth)
-
   "The ContactPreferencesAuthorised.async method" should {
 
     "For a Principal User" when {
@@ -50,7 +45,7 @@ class AuthServiceSpec extends MockAuthConnector with TestUtils {
       "an authorised result is returned from the Auth Connector" should {
 
         "Successfully authenticate and process the request" in {
-          mockAuthRetrieveMtdVatEnrolled(authPredicate)
+          mockAuthenticated(EmptyPredicate)
           status(result) shouldBe OK
         }
       }
@@ -61,7 +56,7 @@ class AuthServiceSpec extends MockAuthConnector with TestUtils {
       "they are Signed Up to MTD ContactPreferences" should {
 
         "Successfully authenticate and process the request" in {
-          mockAuthRetrieveAgentServicesEnrolled(authPredicate)
+          mockAuthRetrieveAgentServicesEnrolled(EmptyPredicate)
           status(result) shouldBe OK
         }
       }
@@ -72,12 +67,12 @@ class AuthServiceSpec extends MockAuthConnector with TestUtils {
       "a NoActiveSession exception is returned from the Auth Connector" should {
 
         "Return a unauthorised response" in {
-          mockAuthorise(authPredicate, retrievals)(Future.failed(MissingBearerToken()))
+          mockAuthorise(EmptyPredicate, retrievals)(Future.failed(MissingBearerToken()))
           status(result) shouldBe UNAUTHORIZED
         }
 
         "Return the correct unauthorised response message" in {
-          mockAuthorise(authPredicate, retrievals)(Future.failed(MissingBearerToken()))
+          mockAuthorise(EmptyPredicate, retrievals)(Future.failed(MissingBearerToken()))
           await(bodyOf(result)) shouldBe "The request was not authenticated"
         }
       }
@@ -85,12 +80,12 @@ class AuthServiceSpec extends MockAuthConnector with TestUtils {
       "an InsufficientAuthority exception is returned from the Auth Connector" should {
 
         "Return a forbidden response" in {
-          mockAuthorise(authPredicate, retrievals)(Future.failed(InsufficientEnrolments()))
+          mockAuthorise(EmptyPredicate, retrievals)(Future.failed(InsufficientEnrolments()))
           status(result) shouldBe FORBIDDEN
         }
 
         "Return the correct unauthorised response message" in {
-          mockAuthorise(authPredicate, retrievals)(Future.failed(InsufficientEnrolments()))
+          mockAuthorise(EmptyPredicate, retrievals)(Future.failed(InsufficientEnrolments()))
           await(bodyOf(result)) shouldBe "The request was authenticated but the user does not have the necessary authority"
         }
       }

--- a/test/services/mocks/MockAuthService.scala
+++ b/test/services/mocks/MockAuthService.scala
@@ -16,22 +16,15 @@
 
 package services.mocks
 
-import assets.BaseTestConstants.testVatNumber
-import config.Constants
 import connectors.mocks.MockAuthConnector
 import services.AuthService
-import uk.gov.hmrc.auth.core.authorise.Predicate
+import uk.gov.hmrc.auth.core.Enrolments
 import uk.gov.hmrc.auth.core.retrieve.{Retrieval, Retrievals}
-import uk.gov.hmrc.auth.core.{Enrolment, Enrolments}
 import utils.TestUtils
 
 trait MockAuthService extends MockAuthConnector with TestUtils {
 
   lazy val mockAuthService = new AuthService(mockAuthConnector, appConfig)
-
-  val vatAuthPredicate: Predicate = Enrolment(Constants.MtdContactPreferencesEnrolmentKey)
-    .withIdentifier(Constants.MtdContactPreferencesReferenceKey, testVatNumber)
-    .withDelegatedAuthRule(Constants.MtdContactPreferencesDelegatedAuth)
 
   val allEnrolments: Retrieval[Enrolments] = Retrievals.allEnrolments
 


### PR DESCRIPTION
Authenticate only; don't predicate on existence of enrolment.